### PR TITLE
focus-visibleもpostcss-preset-env経由で使用するようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Base
 
 Other major libraries
 
-- [focus-visible](https://github.com/WICG/focus-visible)
+- [postcss-preset-env](https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env)
 
 ## Features
 

--- a/css/style.css
+++ b/css/style.css
@@ -143,7 +143,7 @@ main {
     background-color 0.3s;
 }
 
-.main-section-contents__btn:not(.focus-visible) {
+.main-section-contents__btn:not(:focus-visible) {
   outline: none;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,2 +1,1 @@
 import '../css/style.css';
-import 'focus-visible';

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  plugins: [require('postcss-preset-env')],
+  plugins: [
+    require('postcss-preset-env')({
+      features: {
+        'focus-visible-pseudo-class': { enableClientSidePolyfills: true },
+      },
+    }),
+  ],
 };


### PR DESCRIPTION
## Issue 番号
<!-- ※マージとともクローズの場合は closes をつける -->
closes #18 

## 対応内容
- focus-visible も postcss-preset-env 経由で使用するようにした
  - 別パッケージのポリフィルを読み込むよう設定を追加
  - 元々、focus-visible をインポートしていたのを削除